### PR TITLE
Add a new rule: _range

### DIFF
--- a/jsoncomparison/ignore.py
+++ b/jsoncomparison/ignore.py
@@ -48,6 +48,8 @@ class Ignore(ABC):
             return cls._ignore_values(obj, rule)
         if key == '_list':
             return cls._ignore_list_items(obj, rule)
+        if key == '_range':
+            return cls._ignore_range(obj, rule)
         return obj
 
     @classmethod
@@ -61,4 +63,11 @@ class Ignore(ABC):
             return [x for x in obj if x not in black_list]
         if t is dict:
             return {k: obj[k] for k in obj if k not in black_list}
+        return obj
+
+    @classmethod
+    def _ignore_range(cls, obj, rule):
+        t = type(obj)
+        if t is int or t is float:
+            return rule[0] <= obj and obj <= rule[1]
         return obj

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -77,6 +77,21 @@ class IgnoreTestCase(unittest.TestCase):
             ],
         )
 
+    def test_ignore_range(self):
+        obj = {'a': 1.0}
+        rules = {
+            'a': {
+                '_range': [0.9, 1.1],
+            },
+        }
+
+        obj = Ignore.transform(obj, rules)
+        self.assertEqual(
+            obj, {
+                'a': True
+            },
+        )
+
     def test_deep_analyzing(self):
         obj = load_json('ignore/object.json')
         rules = load_json('ignore/rules.json')


### PR DESCRIPTION
I'd like to propose a new rule, _range, which accepts a number property with a value within given range (accepts or ignores, that is synonymous in this context). This is needed for validating properties that we want to let fluctuate, such as performance metrics or similarity values.

In the code, I wanted to remove the json property targeted by the _range key but I couldn't find a way of doing that. Instead, it is transformed into true/false depending if it's within the range or not. The effect should be same, since the expected json and actual json are both transformed before comparison.

If there's a preferred way of implementing this, please let me know and I'll adjust the code accordingly.