### PR TITLE
List of objects ignore handling

### DIFF
--- a/jsoncomparison/ignore.py
+++ b/jsoncomparison/ignore.py
@@ -27,7 +27,10 @@ class Ignore(ABC):
     @classmethod
     def _apply_listable_rule(cls, obj, rules):
         for key in rules:
-            if key in obj:
+            if type(key) is dict:
+                for index, y in enumerate(obj):
+                    obj[index] = cls.transform(obj[index], key)
+            elif key in obj:
                 del obj[key]
         return obj
 

--- a/jsoncomparison/ignore.py
+++ b/jsoncomparison/ignore.py
@@ -26,9 +26,9 @@ class Ignore(ABC):
 
     @classmethod
     def _apply_listable_rule(cls, obj, rules):
-        for i in rules:
-            if i in obj:
-                del obj[i]
+        for key in rules:
+            if key in obj:
+                del obj[key]
         return obj
 
     @classmethod

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -77,6 +77,57 @@ class IgnoreTestCase(unittest.TestCase):
             ],
         )
 
+    def test_ignore_list_items_without_special_rule(self):
+        obj = [
+            {'a': 1, 'b': 2, 'c': 3},
+            {'a': 4, 'b': 5, 'c': 6},
+        ]
+        rules = [{'a': "*", 'c': "*"}]
+
+        obj = Ignore.transform(obj, rules)
+        self.assertEqual(
+            obj, [
+                {'b': 2},
+                {'b': 5},
+            ],
+        )
+
+    def test_ignore_list_object_with_special_rule(self):
+        obj = {
+            'a': {
+                'b': [{
+                    'd': 1,
+                    'e': [{'f': {'g': 2, 'h': 3}}, {'f': {'g': 4, 'h': 5}}],
+                    'i': 6,
+                    'j': None,
+                }],
+            },
+        }
+
+        rules = {
+            'a': {
+                'b': {
+                    '_list': {
+                        'j': '*',
+                        'e': {'_list': {'f': {'g': '*'}}},
+                    },
+                },
+            },
+        }
+
+        obj = Ignore.transform(obj, rules)
+        self.assertEqual(
+            obj, {
+                'a': {
+                    'b': [{
+                        'd': 1,
+                        'e': [{'f': {'h': 3}}, {'f': {'h': 5}}],
+                        'i': 6,
+                    }],
+                },
+            },
+        )
+
     def test_ignore_list_object(self):
         obj = {
             'a': {

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -77,6 +77,40 @@ class IgnoreTestCase(unittest.TestCase):
             ],
         )
 
+    def test_ignore_list_object(self):
+        obj = {
+            'a': {
+                'b': [{
+                    'd': 1,
+                    'e': [{'f': {'g': 2, 'h': 3}}, {'f': {'g': 4, 'h': 5}}],
+                    'i': 6,
+                    'j': None,
+                }],
+            },
+        }
+
+        rules = {
+            'a': {
+                'b': [{
+                    'j': '*',
+                    'e': [{'f': {'g': '*'}}],
+                }],
+            },
+        }
+
+        obj = Ignore.transform(obj, rules)
+        self.assertEqual(
+            obj, {
+                'a': {
+                    'b': [{
+                        'd': 1,
+                        'e': [{'f': {'h': 3}}, {'f': {'h': 5}}],
+                        'i': 6,
+                    }],
+                },
+            },
+        )
+
     def test_ignore_range(self):
         obj = {'a': 1.0}
         rules = {


### PR DESCRIPTION
The special case '_list' can actually handle list of objects (as needed in #24). The new code removes the need of the special case at all (which could be deprecated).

