### PR TITLE
Adding regex handling as special case

### DIFF
--- a/jsoncomparison/ignore.py
+++ b/jsoncomparison/ignore.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC
 
 
@@ -18,6 +19,8 @@ class Ignore(ABC):
             rule = rules[key]
             if cls._is_special_key(key):
                 obj = cls._apply_special_rule(key, obj, rule)
+            elif cls._is_regex_rule(rule):
+                obj = cls._apply_regex_rule(key, obj, rule)
             elif type(rule) is str:
                 obj = cls._apply_stringable_rule(key, obj, rule)
             elif key in obj:
@@ -36,6 +39,17 @@ class Ignore(ABC):
         if rule == '*':
             if key in obj:
                 del obj[key]
+        return obj
+
+    @classmethod
+    def _is_regex_rule(cls, rule):
+        return type(rule) is dict and '_re' in rule
+
+    @classmethod
+    def _apply_regex_rule(cls, key, obj, rule):
+        regex = rule['_re']
+        if key in obj and re.match(regex, obj[key]):
+            del obj[key]
         return obj
 
     @classmethod

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -100,6 +100,30 @@ class IgnoreTestCase(unittest.TestCase):
         obj = Ignore.transform(obj, rules)
         self.assertEqual(obj, expected)
 
+    def test_regex_rules_usage(self):
+        obj = {'a': 1, 'b': 'some_value_that_matches', 'c': 3, 'd': 4}
+
+        rules = {
+            'b': {'_re': '^some_va'},
+        }
+
+        obj = Ignore.transform(obj, rules)
+        self.assertEqual(
+            obj, {'a': 1, 'c': 3, 'd': 4},
+        )
+
+    def test_regex_rules_usage_not_matching(self):
+        obj = {'a': 1, 'b': "non_match_value", 'c': 3, 'd': 4}
+
+        rules = {
+            'b': {'_re': '^some_va'},
+        }
+
+        obj = Ignore.transform(obj, rules)
+        self.assertEqual(
+            obj, {'a': 1, 'b': 'non_match_value', 'c': 3, 'd': 4},
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds a special case for regex to solve #32 

This is the easiest version possible following what is already present.

A better solution, probably, is to convert stringable to be handled as a regex. But that will require a config option, as `"*"` wouldn't work and would need to be converted to `".*"` by the user